### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   java-server:
-    image: guardcraft-java-server
+    image: guardcraft-java
     build:
       context: .
     restart: unless-stopped


### PR DESCRIPTION
Since we docker build the image with the tag guardcraft-java, we can update the docker compose file to reflect the same tag. It would still be able to build the image using the Dockerfile in the same folder , but will error if tried to build from a different one.